### PR TITLE
InvalidArgumentException if $className starts with a backslash

### DIFF
--- a/Classes/Logger/GelfLogger.php
+++ b/Classes/Logger/GelfLogger.php
@@ -96,7 +96,7 @@ class GelfLogger
 	protected function getTransport()
 	{
 		return \tx_rnbase::makeInstance(
-			'\DMK\Mklog\WatchDog\Transport\Gelf\UdpGelf'
+			'DMK\Mklog\WatchDog\Transport\Gelf\UdpGelf'
 		);
 	}
 }


### PR DESCRIPTION
This is documented for \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance in
https://typo3.org/api/typo3cms/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_utility_1_1_general_utility.html#a99623a1a2f1f8369d19d0e58c7feb4b0