### PR TITLE
Fix #16 ensure getGelfCredentials() returns string

### DIFF
--- a/Classes/Utility/ConfigUtility.php
+++ b/Classes/Utility/ConfigUtility.php
@@ -235,7 +235,7 @@ class ConfigUtility implements \TYPO3\CMS\Core\SingletonInterface
      */
     public function getGelfCredentials(): string
     {
-        return $this->getExtConf('gelf_credentials');
+        return $this->getExtConf('gelf_credentials', '');
     }
 
     /**


### PR DESCRIPTION
Fix broken TYPO3 after install.